### PR TITLE
v3.3.1 release candidate

### DIFF
--- a/bin/annotate_blast_lca.py
+++ b/bin/annotate_blast_lca.py
@@ -346,7 +346,7 @@ def main() -> None:
             .pipe(with_canonical_taxids, tx)
             .pipe(with_score_context)
         )
-        assignment_lf = assign_taxonomic_consensus(hits, tx)
+        assignment_lf = assign_taxonomic_consensus(hits, tx).select(OUTPUT_COLUMNS)
         require_taxonomic_assignments(assignment_lf)
 
         logger.info("Writing annotated results to {}", args.output_file)

--- a/bin/test_annotate_blast_lca.py
+++ b/bin/test_annotate_blast_lca.py
@@ -20,7 +20,33 @@ from annotate_blast_lca import (
     main,
     parse_args,
 )
+from concatenate_tsvs import main as concatenate_tsvs
 from py_nvd import taxonomy
+
+EXPECTED_OUTPUT_COLUMNS = [
+    "task",
+    "sample",
+    "qseqid",
+    "qlen",
+    "sseqid",
+    "stitle",
+    "length",
+    "pident",
+    "evalue",
+    "bitscore",
+    "sscinames",
+    "staxids",
+    "rank",
+    "adjusted_taxid",
+    "adjusted_taxid_name",
+    "adjusted_taxid_rank",
+    "adjustment_method",
+]
+
+
+def read_tsv_header(path: Path) -> list[str]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return next(csv.reader(handle, delimiter="\t"))
 
 
 @pytest.fixture
@@ -142,12 +168,12 @@ class TestEndToEnd:
         blast_file = tmp_path / "close_scoring_taxids.tsv"
         blast_file.write_text(
             """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_edge\t216\tref|human-best\tHuman best\t214\t100\t1e-100\t396\tHomo sapiens\t9606
-megablast\tsample1\tcontig_edge\t216\tref|chimp-close\tChimp close\t214\t99.5\t1e-99\t390\tPan troglodytes\t9598
-megablast\tsample1\tcontig_edge\t216\tref|sparse-close\tSparse close\t10\t20.0\t1\t390\tSparse-lineage test species\t6001
-megablast\tsample1\tcontig_edge\t216\tref|test-close\tTest close\t214\t99.0\t1e-98\t385\tTest species one\t5001
-megablast\tsample1\tcontig_edge\t216\tref|human-distant\tHuman distant\t214\t98.0\t1e-90\t374\tHomo sapiens\t9606
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_edge\t216\tref|human-best\tHuman best\t214\t100\t1e-100\t396\tHomo sapiens\t9606\tspecies:Homo sapiens
+megablast\tsample1\tcontig_edge\t216\tref|chimp-close\tChimp close\t214\t99.5\t1e-99\t390\tPan troglodytes\t9598\tspecies:Pan troglodytes
+megablast\tsample1\tcontig_edge\t216\tref|sparse-close\tSparse close\t10\t20.0\t1\t390\tSparse-lineage test species\t6001\tspecies:Sparse-lineage test species
+megablast\tsample1\tcontig_edge\t216\tref|test-close\tTest close\t214\t99.0\t1e-98\t385\tTest species one\t5001\tspecies:Test species one
+megablast\tsample1\tcontig_edge\t216\tref|human-distant\tHuman distant\t214\t98.0\t1e-90\t374\tHomo sapiens\t9606\tspecies:Homo sapiens
 """,
         )
         output_file = tmp_path / "output.tsv"
@@ -166,6 +192,7 @@ megablast\tsample1\tcontig_edge\t216\tref|human-distant\tHuman distant\t214\t98.
             sys.argv = original_argv
 
         output = pl.read_csv(output_file, separator="\t")
+        assert output.columns == EXPECTED_OUTPUT_COLUMNS
         assert output.height == 5
         assert set(output["sseqid"]) == {
             "ref|human-best",
@@ -184,6 +211,66 @@ megablast\tsample1\tcontig_edge\t216\tref|human-distant\tHuman distant\t214\t98.
             "adjustment_method": "lca",
         }
 
+    def test_populated_and_no_hit_outputs_share_schema_and_concatenate(
+        self,
+        test_taxonomy_sqlite: Path,
+        mock_taxonomy_open,
+        tmp_path: Path,
+    ) -> None:
+        """Populated and no-hit outputs expose one canonical downstream schema."""
+        populated_input = tmp_path / "populated-input.tsv"
+        populated_input.write_text(
+            "\t".join(EXPECTED_OUTPUT_COLUMNS[:13])
+            + "\n"
+            + "megablast\tsample1\tcontig1\t500\tref|human\tHuman\t450\t99.5"
+            "\t1e-100\t800\tHomo sapiens\t9606\tspecies:Homo sapiens\n",
+            encoding="utf-8",
+        )
+        no_hit_input = tmp_path / "no-hit-input.tsv"
+        no_hit_input.write_text(
+            "\t".join(EXPECTED_OUTPUT_COLUMNS[:13]) + "\n",
+            encoding="utf-8",
+        )
+        populated_output = tmp_path / "a-populated-output.tsv"
+        no_hit_output = tmp_path / "b-no-hit-output.tsv"
+
+        original_argv = sys.argv
+        try:
+            for input_file, output_file in (
+                (populated_input, populated_output),
+                (no_hit_input, no_hit_output),
+            ):
+                sys.argv = [
+                    "annotate_blast_lca.py",
+                    "--input-file",
+                    str(input_file),
+                    "--output-file",
+                    str(output_file),
+                ]
+                main()
+        finally:
+            sys.argv = original_argv
+
+        assert OUTPUT_COLUMNS == EXPECTED_OUTPUT_COLUMNS
+        assert read_tsv_header(populated_output) == EXPECTED_OUTPUT_COLUMNS
+        assert read_tsv_header(no_hit_output) == EXPECTED_OUTPUT_COLUMNS
+
+        combined_output = tmp_path / "combined.tsv"
+        concatenate_tsvs(
+            [
+                "--input",
+                str(no_hit_output),
+                str(populated_output),
+                "--output",
+                str(combined_output),
+            ],
+        )
+
+        assert read_tsv_header(combined_output) == EXPECTED_OUTPUT_COLUMNS
+        assert pl.read_csv(combined_output, separator="\t").equals(
+            pl.read_csv(populated_output, separator="\t"),
+        )
+
 
 class TestTaxonomicConsensus:
     """Behavioral tests for taxonomic consensus output."""
@@ -197,11 +284,11 @@ class TestTaxonomicConsensus:
         """A reference at 95% participates while one below 95% does not."""
         blast_file = tmp_path / "threshold_test.txt"
         content = """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_at_boundary\t500\tref|NC_001\tHuman\t450\t99.5\t1e-100\t100\tHomo sapiens\t9606
-megablast\tsample1\tcontig_at_boundary\t500\tref|NC_002\tChimp\t450\t99.0\t1e-90\t95\tPan troglodytes\t9598
-megablast\tsample1\tcontig_below_boundary\t500\tref|NC_003\tHuman\t450\t99.5\t1e-100\t100\tHomo sapiens\t9606
-megablast\tsample1\tcontig_below_boundary\t500\tref|NC_004\tChimp\t450\t99.0\t1e-90\t94.9\tPan troglodytes\t9598
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_at_boundary\t500\tref|NC_001\tHuman\t450\t99.5\t1e-100\t100\tHomo sapiens\t9606\tspecies:Homo sapiens
+megablast\tsample1\tcontig_at_boundary\t500\tref|NC_002\tChimp\t450\t99.0\t1e-90\t95\tPan troglodytes\t9598\tspecies:Pan troglodytes
+megablast\tsample1\tcontig_below_boundary\t500\tref|NC_003\tHuman\t450\t99.5\t1e-100\t100\tHomo sapiens\t9606\tspecies:Homo sapiens
+megablast\tsample1\tcontig_below_boundary\t500\tref|NC_004\tChimp\t450\t99.0\t1e-90\t94.9\tPan troglodytes\t9598\tspecies:Pan troglodytes
 """
         blast_file.write_text(content)
 
@@ -244,9 +331,9 @@ megablast\tsample1\tcontig_below_boundary\t500\tref|NC_004\tChimp\t450\t99.0\t1e
         """Merged taxids are canonicalized before method selection."""
         blast_file = tmp_path / "merged_test.txt"
         content = """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_merged\t500\tref|NC_001\tOld Human ID\t450\t99.5\t1e-100\t800\tHomo sapiens\t12345
-megablast\tsample1\tcontig_merged\t500\tref|NC_001\tOld Human ID\t450\t99.5\t1e-100\t800\tHomo sapiens\t9606
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_merged\t500\tref|NC_001\tOld Human ID\t450\t99.5\t1e-100\t800\tHomo sapiens\t12345\tspecies:Homo sapiens
+megablast\tsample1\tcontig_merged\t500\tref|NC_001\tOld Human ID\t450\t99.5\t1e-100\t800\tHomo sapiens\t9606\tspecies:Homo sapiens
 """
         blast_file.write_text(content)
 
@@ -289,9 +376,9 @@ megablast\tsample1\tcontig_merged\t500\tref|NC_001\tOld Human ID\t450\t99.5\t1e-
         blast_file = tmp_path / "invalid_taxid.tsv"
         blast_file.write_text(
             """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_invalid\t500\tref|valid\tHuman\t450\t99.5\t1e-100\t800\tHomo sapiens\t9606
-megablast\tsample1\tcontig_invalid\t500\tref|invalid\tUnknown\t450\t99.5\t1e-100\t800\tUnknown\t999999999
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_invalid\t500\tref|valid\tHuman\t450\t99.5\t1e-100\t800\tHomo sapiens\t9606\tspecies:Homo sapiens
+megablast\tsample1\tcontig_invalid\t500\tref|invalid\tUnknown\t450\t99.5\t1e-100\t800\tUnknown\t999999999\tno rank:Unknown
 """,
         )
         output_file = tmp_path / "output.tsv"
@@ -335,9 +422,9 @@ megablast\tsample1\tcontig_invalid\t500\tref|invalid\tUnknown\t450\t99.5\t1e-100
         blast_file = tmp_path / "unranked_lca.tsv"
         blast_file.write_text(
             """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_unranked\t500\tref|one\tOne\t450\t99.5\t1e-100\t800\tTest species one\t5001
-megablast\tsample1\tcontig_unranked\t500\tref|two\tTwo\t450\t99.5\t1e-100\t800\tTest species two\t5002
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_unranked\t500\tref|one\tOne\t450\t99.5\t1e-100\t800\tTest species one\t5001\tspecies:Test species one
+megablast\tsample1\tcontig_unranked\t500\tref|two\tTwo\t450\t99.5\t1e-100\t800\tTest species two\t5002\tspecies:Test species two
 """,
         )
         output_file = tmp_path / "output.tsv"
@@ -382,8 +469,8 @@ megablast\tsample1\tcontig_unranked\t500\tref|two\tTwo\t450\t99.5\t1e-100\t800\t
         blast_file = tmp_path / "unavailable_taxids.tsv"
         blast_file.write_text(
             """\
-task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids
-megablast\tsample1\tcontig_unavailable\t500\tref|invalid\tUnknown\t450\t99.5\t1e-100\t800\tUnknown\t999999999
+task\tsample\tqseqid\tqlen\tsseqid\tstitle\tlength\tpident\tevalue\tbitscore\tsscinames\tstaxids\trank
+megablast\tsample1\tcontig_unavailable\t500\tref|invalid\tUnknown\t450\t99.5\t1e-100\t800\tUnknown\t999999999\tno rank:Unknown
 """,
         )
         output_file = tmp_path / "output.tsv"
@@ -434,7 +521,8 @@ megablast\tsample1\tcontig_unavailable\t500\tref|invalid\tUnknown\t450\t99.5\t1e
         with output_file.open(newline="") as handle:
             rows = list(csv.reader(handle, delimiter="\t"))
 
-        assert rows == [OUTPUT_COLUMNS]
+        assert OUTPUT_COLUMNS == EXPECTED_OUTPUT_COLUMNS
+        assert rows == [EXPECTED_OUTPUT_COLUMNS]
 
     def test_header_only_input_creates_header_only_output(
         self,
@@ -467,4 +555,5 @@ megablast\tsample1\tcontig_unavailable\t500\tref|invalid\tUnknown\t450\t99.5\t1e
         with output_file.open(newline="") as handle:
             rows = list(csv.reader(handle, delimiter="\t"))
 
-        assert rows == [OUTPUT_COLUMNS]
+        assert OUTPUT_COLUMNS == EXPECTED_OUTPUT_COLUMNS
+        assert rows == [EXPECTED_OUTPUT_COLUMNS]

--- a/lib/py_nvd/__init__.py
+++ b/lib/py_nvd/__init__.py
@@ -1,6 +1,6 @@
 """NVD CLI and pipeline helper library."""
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 # Re-export key modules for convenient access.
 from py_nvd import models, params, paths, presets, taxonomy

--- a/modules/bbmap.nf
+++ b/modules/bbmap.nf
@@ -19,12 +19,26 @@ process MERGE_PAIRS {
 
 	script:
 	"""
+	set -o pipefail
+
+	# Preserve mate identity before later single-read filtering can orphan pairs.
 	bbmerge.sh \
 	in=${reads} \
 	out=${sample_id}.overlap_merged_pair.fastq.gz \
-	outu=${sample_id}.single_read.fastq.gz \
+	outu=stdout.fq \
 	interleaved=t \
 	threads=${task.cpus} \
+	-eoom \
+	| reformat.sh \
+	in=stdin.fq \
+	out=${sample_id}.single_read.fastq.gz \
+	interleaved=t \
+	verifyinterleaved=t \
+	trimreaddescription=t \
+	addslash=t \
+	spaceslash=f \
+	changequality=f \
+	threads=1 \
 	-eoom
 	"""
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -347,7 +347,7 @@ manifest {
     homePage      = ''
     mainScript    = 'main.nf'
     defaultBranch = 'main'
-    version       = '3.3.0'
+    version       = '3.3.1'
     description   = ''
     author        = ''
 }

--- a/pixi.lock
+++ b/pixi.lock
@@ -362,6 +362,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e1/66/ef5dda05aa8d4e975f9186b806e18e4ca50ef1d2e2a043313c2d287ea7ca/labkey-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/93/e56ad292521e913c2f44281ff430bb1738ed0a63fc4ce0db36fa4a61be17/sourmash_utils-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -697,6 +698,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e1/66/ef5dda05aa8d4e975f9186b806e18e4ca50ef1d2e2a043313c2d287ea7ca/labkey-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/93/e56ad292521e913c2f44281ff430bb1738ed0a63fc4ce0db36fa4a61be17/sourmash_utils-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -988,6 +990,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e1/66/ef5dda05aa8d4e975f9186b806e18e4ca50ef1d2e2a043313c2d287ea7ca/labkey-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/93/e56ad292521e913c2f44281ff430bb1738ed0a63fc4ce0db36fa4a61be17/sourmash_utils-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl
@@ -1282,6 +1285,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e1/66/ef5dda05aa8d4e975f9186b806e18e4ca50ef1d2e2a043313c2d287ea7ca/labkey-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/99/d6031f4f146298951c46b1bf1cc160c2a63f6e44b3c13a30054add100d5f/altair-6.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/93/e56ad292521e913c2f44281ff430bb1738ed0a63fc4ce0db36fa4a61be17/sourmash_utils-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl
@@ -1726,6 +1730,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl
@@ -2168,6 +2173,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl
@@ -2575,6 +2581,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl
@@ -2979,6 +2986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl
@@ -20761,6 +20769,7 @@ packages:
   - labkey>=3.4.0
   - loguru>=0.7.3
   - lxml>=5.4.0
+  - more-itertools>=10.7.0
   - numpy>=2.0.0
   - pandas>=2.2.3
   - polars>=1.27.1
@@ -24635,6 +24644,11 @@ packages:
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
   - pytest<9 ; extra == 'test'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+  name: more-itertools
+  version: 11.1.0
+  sha256: 4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/e8/f7/47bddf95492f4d1370ed7164d2b16407805e8eeb38231361de65d387a562/matplotlib-venn-1.1.2.tar.gz
   name: matplotlib-venn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "labkey>=3.4.0",
   "loguru>=0.7.3",
   "lxml>=5.4.0",
+  "more-itertools>=10.7.0",
   "numpy>=2.0.0",
   "pandas>=2.2.3",
   "polars>=1.27.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "William Gardner", email = "wkgardner@wisc.edu" },
 ]
 requires-python = ">= 3.11, < 3.14"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
   "altair>=6.1.0",
   "biopython>=1.85",

--- a/uv.lock
+++ b/uv.lock
@@ -1724,7 +1724,7 @@ wheels = [
 
 [[package]]
 name = "nvd"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
This release candidate addresses a few bugs discovered after v3.3 was merged.

First, it seems `more-itertools` was removed prematurely. This release brings it back into our explicit PyPI dependencies. This includes changes to `pixi.lock` and `uv.lock`.

Second and more critically, we discovered a subtle bug related to paired read ID handling in minimap2. This bug is now possible because NVD splits out single reads when pair merging is turned on. In that case, two reads from the same pair may both end up in a single read FASTQ. If those pairs use Illumina CASAVA conventions, their IDs will be the same, with pair membership being annotated after a space delimiter. This space delimited information is lost in minimap2 alignment. As a result, when NVD goes to assign each read an nvd query identifier, it can encounter the two members of that pair, both with the same ID. This currently isn't allowed with how NVD assigns identifiers and triggers an assertion. To get around this, single reads are now relabeled as part of the read merging process to ensure all read IDs downstream are unique. Who would've thought FASTQ would cause so many little problems like this!

And third, the BLAST LCA annotation script contained a small bug where it would output slightly different columns in a different order for empty no-op results than it would for successful BLAST results. That would then trip up our BLAST uploads. This release fixes that bug.