### PR TITLE
v3.3.2 release candidate

### DIFF
--- a/lib/py_nvd/__init__.py
+++ b/lib/py_nvd/__init__.py
@@ -1,6 +1,6 @@
 """NVD CLI and pipeline helper library."""
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 
 # Re-export key modules for convenient access.
 from py_nvd import models, params, paths, presets, taxonomy

--- a/lib/py_nvd/cli/commands/run.py
+++ b/lib/py_nvd/cli/commands/run.py
@@ -438,7 +438,7 @@ def run(
     min_read_entropy: float | None = typer.Option(
         None,
         "--min-read-entropy",
-        help="Minimum normalized 5-mer entropy over 50-base windows (default: 0.9)",
+        help="Minimum normalized 5-mer entropy over 50-base windows (default: 0.5)",
         rich_help_panel=PANEL_PREPROCESSING,
     ),
     # -------------------------------------------------------------------------

--- a/lib/py_nvd/cli/test_cli_smoke.py
+++ b/lib/py_nvd/cli/test_cli_smoke.py
@@ -216,6 +216,14 @@ def test_run_accepts_low_complexity_read_filter_options(tmp_path: Path) -> None:
     assert "0.65" in result.output
 
 
+def test_run_help_describes_moderate_read_entropy_default() -> None:
+    """CLI help identifies the corrective low-complexity threshold."""
+    result = runner.invoke(app, ["run", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "default: 0.5" in result.output
+
+
 def test_samplesheet_generate_sanitizes_illumina_ids(tmp_path: Path) -> None:
     fastq_dir = tmp_path / "fastqs"
     fastq_dir.mkdir()

--- a/lib/py_nvd/models.py
+++ b/lib/py_nvd/models.py
@@ -291,7 +291,7 @@ class NvdParams(BaseModel):
         json_schema_extra={"category": "Preprocessing"},
     )
     min_read_entropy: float = Field(
-        0.9,
+        0.5,
         description="Minimum normalized 5-mer entropy over 50-base windows (0-1)",
         json_schema_extra={"category": "Preprocessing"},
     )

--- a/lib/py_nvd/params.py
+++ b/lib/py_nvd/params.py
@@ -22,7 +22,7 @@ import yaml
 SCHEMA_FILENAME = "nvd-params.latest.schema.json"
 
 # GitHub raw URL for schema (fallback and for generated templates)
-SCHEMA_URL = "https://raw.githubusercontent.com/dholab/nvd/main/schemas/nvd-params.v3.3.0.schema.json"
+SCHEMA_URL = "https://raw.githubusercontent.com/dholab/nvd/main/schemas/nvd-params.v3.3.2.schema.json"
 
 
 def _find_schema_path() -> Path:

--- a/lib/py_nvd/test_models.py
+++ b/lib/py_nvd/test_models.py
@@ -570,7 +570,7 @@ class TestNvdParamsDefaults:
         """Low-complexity read filtering is opt-in with a dormant threshold."""
         params = NvdParams()
         assert params.filter_low_complexity_reads is False
-        assert params.min_read_entropy == 0.9
+        assert params.min_read_entropy == 0.5
 
     def test_default_experimental(self) -> None:
         """Default experimental gate matches nextflow.config."""

--- a/lib/py_nvd/test_version_sync.py
+++ b/lib/py_nvd/test_version_sync.py
@@ -6,6 +6,7 @@ import tomllib
 from pathlib import Path
 
 from py_nvd import __version__
+from py_nvd.models import NvdParams
 from py_nvd.params import SCHEMA_URL
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -27,13 +28,48 @@ def test_python_and_nextflow_versions_match_project_version() -> None:
     assert manifest_match.group(1) == project_version
 
 
-def test_latest_params_schema_points_to_v3_3() -> None:
-    """The rolling schema link should expose the v3.3 parameter contract."""
+def test_read_entropy_defaults_match_runtime_and_schema() -> None:
+    """Native Nextflow and the Python wrapper should apply the same default."""
+    nextflow_config = (ROOT / "nextflow.config").read_text(encoding="utf-8")
+    config_match = re.search(
+        r"^\s*min_read_entropy\s*=\s*([0-9.]+)",
+        nextflow_config,
+        re.MULTILINE,
+    )
+    latest_schema = json.loads(
+        (ROOT / "schemas" / "nvd-params.latest.schema.json").read_text(
+            encoding="utf-8",
+        ),
+    )
+
+    assert config_match is not None, "nextflow.config min_read_entropy is missing"
+    assert float(config_match.group(1)) == 0.5
+    assert NvdParams().min_read_entropy == 0.5
+    assert latest_schema["properties"]["min_read_entropy"]["default"] == 0.5
+
+
+def test_latest_params_schema_points_to_v3_3_2() -> None:
+    """The rolling schema link should expose the corrected v3.3 defaults."""
     latest_schema = ROOT / "schemas" / "nvd-params.latest.schema.json"
 
     assert latest_schema.is_symlink()
-    assert latest_schema.readlink() == Path("nvd-params.v3.3.0.schema.json")
-    assert SCHEMA_URL.endswith("/nvd-params.v3.3.0.schema.json")
+    assert latest_schema.readlink() == Path("nvd-params.v3.3.2.schema.json")
+    assert SCHEMA_URL.endswith("/nvd-params.v3.3.2.schema.json")
+
+
+def test_v3_3_2_schema_corrects_only_the_read_entropy_default() -> None:
+    """The patch schema preserves the published v3.3.0 default."""
+    original_path = ROOT / "schemas" / "nvd-params.v3.3.0.schema.json"
+    corrected_path = ROOT / "schemas" / "nvd-params.v3.3.2.schema.json"
+    original = json.loads(original_path.read_text(encoding="utf-8"))
+    corrected = json.loads(corrected_path.read_text(encoding="utf-8"))
+
+    assert original["properties"]["min_read_entropy"]["default"] == 0.9
+    assert corrected["properties"]["min_read_entropy"]["default"] == 0.5
+
+    corrected["$id"] = original["$id"]
+    corrected["properties"]["min_read_entropy"]["default"] = 0.9
+    assert corrected == original
 
 
 def test_v3_2_schema_accepts_disabled_optional_read_limits() -> None:

--- a/nextflow.config
+++ b/nextflow.config
@@ -347,7 +347,7 @@ manifest {
     homePage      = ''
     mainScript    = 'main.nf'
     defaultBranch = 'main'
-    version       = '3.3.1'
+    version       = '3.3.2'
     description   = ''
     author        = ''
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -114,7 +114,7 @@ params {
     min_read_quality_nanopore = 12
     min_read_length           = 50
     max_read_length           = null
-    min_read_entropy          = 0.9
+    min_read_entropy          = 0.5
 
     // Optional host/contaminant depletion. Disabled by default; provide at
     // least one host index source to opt in.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "William Gardner", email = "wkgardner@wisc.edu" },
 ]
 requires-python = ">= 3.11, < 3.14"
-version = "3.3.1"
+version = "3.3.2"
 dependencies = [
   "altair>=6.1.0",
   "biopython>=1.85",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -10,6 +10,7 @@ This directory contains JSON Schema definitions for the NVD pipeline.
 | `nvd-params.v3.1.0.schema.json` | Pipeline parameters schema (version 3.1.0) |
 | `nvd-params.v3.2.0.schema.json` | Pipeline parameters schema (version 3.2.0) |
 | `nvd-params.v3.3.0.schema.json` | Pipeline parameters schema (version 3.3.0) |
+| `nvd-params.v3.3.2.schema.json` | Pipeline parameters schema (version 3.3.2) |
 | `nvd-params.latest.schema.json` | Symlink to the current version |
 
 ## Usage
@@ -72,7 +73,7 @@ points to the current version for users who want to track updates automatically.
 For reproducibility, you can reference a specific version:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/dholab/nvd/main/schemas/nvd-params.v3.3.0.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dholab/nvd/main/schemas/nvd-params.v3.3.2.schema.json
 ```
 
 ## Validation

--- a/schemas/nvd-params.latest.schema.json
+++ b/schemas/nvd-params.latest.schema.json
@@ -1,1 +1,1 @@
-nvd-params.v3.3.0.schema.json
+nvd-params.v3.3.2.schema.json

--- a/schemas/nvd-params.v3.3.2.schema.json
+++ b/schemas/nvd-params.v3.3.2.schema.json
@@ -1,0 +1,437 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/dholab/nvd/main/schemas/nvd-params.v3.3.2.schema.json",
+  "title": "NVD Pipeline Parameters",
+  "description": "Parameters for the Novel Virus Detection (NVD) metagenomics pipeline. Use with Nextflow's -params-file option or register as a preset with nvd preset register.",
+  "type": "object",
+  "properties": {
+    "labkey": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable LabKey integration for result uploads. When enabled, all labkey_* params must be set."
+    },
+    "labkey_server": {
+      "type": "string",
+      "description": "LabKey server URL"
+    },
+    "labkey_project_name": {
+      "type": "string",
+      "description": "LabKey project name"
+    },
+    "labkey_webdav": {
+      "type": "string",
+      "description": "LabKey WebDAV endpoint URL"
+    },
+    "labkey_schema": {
+      "type": "string",
+      "description": "LabKey schema name"
+    },
+    "labkey_blast_meta_hits_list": {
+      "type": "string",
+      "description": "LabKey list name for BLAST meta hits"
+    },
+    "labkey_blast_fasta_list": {
+      "type": "string",
+      "description": "LabKey list name for BLAST FASTA uploads"
+    },
+    "samplesheet": {
+      "type": "string",
+      "format": "path",
+      "description": "Path to samplesheet CSV with columns: sample_id, srr, platform, fastq1, fastq2"
+    },
+    "results": {
+      "type": "string",
+      "format": "path",
+      "description": "Directory for pipeline output files"
+    },
+    "experiment_id": {
+      "type": "string",
+      "description": "Experiment identifier for tracking and LabKey integration"
+    },
+    "max_concurrent_downloads": {
+      "type": "integer",
+      "default": 3,
+      "minimum": 1,
+      "description": "Maximum number of concurrent SRA downloads"
+    },
+    "cleanup": {
+      "type": "boolean",
+      "description": "Whether to empty the work directory after successful completion"
+    },
+    "work_dir": {
+      "type": ["string", "null"],
+      "format": "path",
+      "description": "Nextflow work directory for intermediate files"
+    },
+    "experimental": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable experimental release-candidate features that may change or be removed."
+    },
+    "skip_assembly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip SPAdes assembly and all downstream contig classification."
+    },
+    "skip_blast": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip MEGABLAST and BLASTN contig search."
+    },
+    "blast_db_version": {
+      "type": "string",
+      "description": "BLAST database version identifier"
+    },
+    "virus_index_version": {
+      "type": "string",
+      "description": "Virus enrichment index version"
+    },
+    "nvd_files": {
+      "type": "string",
+      "format": "path",
+      "description": "Path to NVD resource files directory"
+    },
+    "blast_db": {
+      "type": "string",
+      "format": "path",
+      "description": "Path to BLAST database directory"
+    },
+    "blast_db_prefix": {
+      "type": "string",
+      "description": "BLAST database name prefix"
+    },
+    "virus_index": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "Path to a prebuilt vertebrate-infecting virus deacon index (.idx file). Providing this enables virus read enrichment."
+    },
+    "virus_index_url": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "URL to download a prebuilt vertebrate-infecting virus deacon index. Providing this enables virus read enrichment when virus_index is not set."
+    },
+    "virus_reference_fasta": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "Custom vertebrate-infecting virus FASTA to build and union with other virus indexes. Providing this enables virus read enrichment."
+    },
+    "no_enrichment": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable target enrichment even when virus_index, virus_index_url, or virus_reference_fasta is set."
+    },
+    "virus_kmer_size": {
+      "type": "integer",
+      "default": 31,
+      "minimum": 1,
+      "description": "K-mer size for building a custom virus enrichment index"
+    },
+    "virus_window_size": {
+      "type": "integer",
+      "default": 1,
+      "minimum": 1,
+      "description": "Minimizer window size for building a custom virus enrichment index"
+    },
+    "virus_abs_threshold": {
+      "type": "integer",
+      "default": 1,
+      "minimum": 1,
+      "description": "Minimum absolute minimizer hits for virus read enrichment"
+    },
+    "virus_rel_threshold": {
+      "type": "number",
+      "default": 0.0,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum relative proportion of minimizers for virus read enrichment (0.0-1.0)"
+    },
+    "sourmash_ref_path": {
+      "type": ["string", "null"],
+      "default": null,
+      "format": "path",
+      "description": "Path to a prebuilt sourmash reference sketch database. When set, this takes precedence over sourmash_ref_url and sourmash_ref_fasta."
+    },
+    "sourmash_ref_url": {
+      "type": ["string", "null"],
+      "default": null,
+      "format": "uri",
+      "description": "URL to download a prebuilt sourmash reference sketch database when sourmash_ref_path is not set."
+    },
+    "sourmash_ref_fasta": {
+      "type": ["string", "null"],
+      "default": null,
+      "format": "path",
+      "description": "Local FASTA to sketch as an experimental sourmash reference database when sourmash_ref_path and sourmash_ref_url are not set."
+    },
+    "sourmash_lineages_path": {
+      "type": ["string", "null"],
+      "default": null,
+      "format": "path",
+      "description": "Path to a sourmash taxonomy lineages CSV matching the reference sketch database. When set, this takes precedence over sourmash_lineages_url."
+    },
+    "sourmash_lineages_url": {
+      "type": ["string", "null"],
+      "default": null,
+      "format": "uri",
+      "description": "URL to download a sourmash taxonomy lineages CSV when sourmash_lineages_path is not set."
+    },
+    "sourmash_ksize": {
+      "type": "integer",
+      "default": 31,
+      "minimum": 1,
+      "description": "K-mer size for experimental sourmash sketching"
+    },
+    "sourmash_scaled": {
+      "type": "integer",
+      "default": 50,
+      "minimum": 1,
+      "description": "Scaled value for experimental sourmash sketching"
+    },
+    "sourmash_threshold_bp": {
+      "type": "integer",
+      "default": 50,
+      "minimum": 0,
+      "description": "Minimum estimated base-pair overlap for experimental sourmash gather"
+    },
+    "preprocess": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable default preprocessing steps before classification"
+    },
+    "merge_pairs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Merge overlapping paired-end reads before contig mapback"
+    },
+    "dedup": {
+      "type": "boolean",
+      "default": false,
+      "description": "Deduplicate sequencing reads (umbrella: enables both dedup_seq and dedup_pos)"
+    },
+    "dedup_seq": {
+      "type": "boolean",
+      "default": false,
+      "description": "Sequence-based deduplication with clumpify (preprocessing)"
+    },
+    "dedup_pos": {
+      "type": "boolean",
+      "default": false,
+      "description": "Positional deduplication with samtools markdup (after alignment)"
+    },
+    "trim_adapters": {
+      "type": "boolean",
+      "description": "Trim Illumina adapters from reads"
+    },
+    "filter_reads": {
+      "type": ["boolean", "null"],
+      "default": null,
+      "description": "Apply quality and length filtering to reads"
+    },
+    "filter_low_complexity_reads": {
+      "type": "boolean",
+      "default": false,
+      "description": "Filter reads below the minimum normalized 5-mer entropy"
+    },
+    "min_read_quality_illumina": {
+      "type": "integer",
+      "default": 20,
+      "minimum": 0,
+      "description": "Minimum average quality score for Illumina reads"
+    },
+    "min_read_quality_nanopore": {
+      "type": "integer",
+      "default": 12,
+      "minimum": 0,
+      "description": "Minimum average quality score for Nanopore reads"
+    },
+    "min_read_length": {
+      "type": "integer",
+      "default": 50,
+      "minimum": 1,
+      "description": "Minimum read length to retain"
+    },
+    "max_read_length": {
+      "type": ["integer", "null"],
+      "default": null,
+      "minimum": 1,
+      "description": "Maximum read length to retain (no limit if not specified)"
+    },
+    "min_read_entropy": {
+      "type": "number",
+      "default": 0.5,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum normalized 5-mer entropy over 50-base windows"
+    },
+    "host_index": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "Path to a prebuilt host/contaminant index (.idx file). Providing this enables host depletion."
+    },
+    "host_index_url": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "URL to download a prebuilt host/contaminant index. Providing this enables host depletion when host_index is not set."
+    },
+    "host_contaminants_fasta": {
+      "type": ["string", "null"],
+      "default": null,
+      "description": "Custom contaminant FASTA to build and union with other host indexes. Providing this enables host depletion."
+    },
+    "host_kmer_size": {
+      "type": "integer",
+      "default": 31,
+      "minimum": 1,
+      "description": "K-mer size for building a custom host/contaminant index"
+    },
+    "host_window_size": {
+      "type": "integer",
+      "default": 15,
+      "minimum": 1,
+      "description": "Minimizer window size for building a custom host/contaminant index"
+    },
+    "host_abs_threshold": {
+      "type": "integer",
+      "default": 2,
+      "minimum": 1,
+      "description": "Minimum absolute minimizer hits to classify as contaminant"
+    },
+    "host_rel_threshold": {
+      "type": "number",
+      "default": 0.01,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum relative proportion of minimizers (0.0-1.0)"
+    },
+    "cutoff_percent": {
+      "type": "number",
+      "default": 0.001,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Minimum abundance threshold for reporting taxa (0-1)"
+    },
+    "entropy": {
+      "type": "number",
+      "default": 0.9,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Entropy threshold for sequence complexity filtering (0-1)"
+    },
+    "min_consecutive_bases": {
+      "type": "integer",
+      "default": 200,
+      "minimum": 1,
+      "description": "Minimum number of consecutive bases required"
+    },
+    "qtrim": {
+      "type": "string",
+      "default": "t",
+      "description": "Quality trimming mode"
+    },
+    "tax_stringency": {
+      "type": "number",
+      "default": 0.7,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Stringency for taxonomic classification (0-1)"
+    },
+    "include_children": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include child taxa in taxonomic analysis"
+    },
+    "human_virus_families": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "Adenoviridae",
+        "Anelloviridae",
+        "Arenaviridae",
+        "Arteriviridae",
+        "Astroviridae",
+        "Bornaviridae",
+        "Peribunyaviridae",
+        "Caliciviridae",
+        "Coronaviridae",
+        "Filoviridae",
+        "Flaviviridae",
+        "Hepadnaviridae",
+        "Hepeviridae",
+        "Orthoherpesviridae",
+        "Orthomyxoviridae",
+        "Papillomaviridae",
+        "Paramyxoviridae",
+        "Parvoviridae",
+        "Picobirnaviridae",
+        "Picornaviridae",
+        "Pneumoviridae",
+        "Polyomaviridae",
+        "Poxviridae",
+        "Sedoreoviridae",
+        "Retroviridae",
+        "Rhabdoviridae",
+        "Togaviridae",
+        "Kolmioviridae"
+      ],
+      "description": "List of virus family names to include in human virus analysis"
+    },
+    "max_blast_targets": {
+      "type": "integer",
+      "default": 100,
+      "minimum": 1,
+      "description": "Maximum number of BLAST hits to consider before calling hits"
+    },
+    "blast_retention_count": {
+      "type": "integer",
+      "default": 5,
+      "minimum": 1,
+      "description": "Number of top BLAST hits to retain"
+    },
+    "refman_registry": {
+      "type": "string",
+      "format": "path",
+      "description": "Path to refman registry file for reference management"
+    },
+    "monoimage": {
+      "type": "string",
+      "default": "nrminor/nvd:latest",
+      "description": "Container image to use for pipeline execution"
+    },
+    "slack_enabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable Slack notifications for run completion"
+    },
+    "slack_channel": {
+      "type": "string",
+      "pattern": "^C[A-Z0-9]+$",
+      "description": "Slack channel ID for notifications (e.g., 'C0123456789')"
+    },
+    "taxonomy_dir": {
+      "type": ["string", "null"],
+      "format": "path",
+      "description": "Explicit taxonomy database directory containing NCBI taxdump files. When unset, Python taxonomy helpers resolve the cache location."
+    },
+    "taxonomy_mode": {
+      "type": ["string", "null"],
+      "enum": ["read_only", "missing", null],
+      "default": null,
+      "description": "Pipeline taxonomy availability mode. null preserves legacy NVD_TAXONOMY_OFFLINE behavior; read_only never downloads or rebuilds; missing prepares taxonomy only when required files are absent."
+    },
+    "taxonomy_refresh": {
+      "type": "string",
+      "enum": ["missing", "stale", "force"],
+      "default": "missing",
+      "description": "Admin taxonomy preflight refresh policy. missing downloads/builds only when required files are absent; stale refreshes when older than taxonomy_max_age_days; force always refreshes."
+    },
+    "taxonomy_max_age_days": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 90,
+      "description": "Freshness threshold in days for taxonomy stale refreshes and warnings."
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_read_filtering.py
+++ b/tests/test_read_filtering.py
@@ -40,6 +40,7 @@ def run_filter(
     filter_low_complexity_reads: bool,
     read_structure: str = "single",
     min_read_length: int = 50,
+    min_read_entropy: float = 0.5,
 ) -> str:
     """Run the public FILTER_READS Nextflow process and return its FASTQ text."""
     reads = tmp_path / "reads.fastq.gz"
@@ -52,7 +53,7 @@ nextflow.enable.dsl = 2
 
 params.filter_reads = {str(filter_reads).lower()}
 params.filter_low_complexity_reads = {str(filter_low_complexity_reads).lower()}
-params.min_read_entropy = 0.9
+params.min_read_entropy = {min_read_entropy}
 params.min_read_length = {min_read_length}
 params.max_read_length = null
 params.min_read_quality_illumina = 20
@@ -319,8 +320,23 @@ def test_entropy_filter_removes_complete_interleaved_pair(tmp_path: Path) -> Non
     assert output == ""
 
 
-def test_default_entropy_filters_observed_repeat_rich_reads(tmp_path: Path) -> None:
-    """The default rejects seven examples but preserves a mostly complex read."""
+@pytest.mark.parametrize(
+    ("min_read_entropy", "expected_ids"),
+    [
+        (
+            0.5,
+            {"000113", "000139", "000141", "000144", "000146", "control"},
+        ),
+        (0.9, {"000144", "control"}),
+    ],
+    ids=["moderate-default", "strict-compatibility"],
+)
+def test_entropy_thresholds_filter_observed_repeat_rich_reads(
+    tmp_path: Path,
+    min_read_entropy: float,
+    expected_ids: set[str],
+) -> None:
+    """The moderate default removes strong repeats while 0.9 remains available."""
     observed = [
         (
             "000110",
@@ -364,6 +380,7 @@ def test_default_entropy_filters_observed_repeat_rich_reads(tmp_path: Path) -> N
         [(name, sequence, "I" * len(sequence)) for name, sequence in observed],
         filter_reads=False,
         filter_low_complexity_reads=True,
+        min_read_entropy=min_read_entropy,
     )
     retained_ids = {
         line.removeprefix("@")
@@ -371,7 +388,7 @@ def test_default_entropy_filters_observed_repeat_rich_reads(tmp_path: Path) -> N
         if index % 4 == 0
     }
 
-    assert retained_ids == {"000144", "control"}
+    assert retained_ids == expected_ids
 
 
 def test_either_filter_family_schedules_filter_reads() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1724,7 +1724,7 @@ wheels = [
 
 [[package]]
 name = "nvd"
-version = "3.3.1"
+version = "3.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
This patch release corrects the default normalized read-entropy threshold used when low-complexity read filtering is enabled.

NVD previously used `min_read_entropy = 0.9`. BBDuk calculates average normalized 5-mer entropy across 50-base sliding windows, making 0.9 substantially more stringent than intended and causing biologically plausible repeat-bearing reads to be discarded. The corrected default is 0.5, matching the upstream BBDuk entropy-filtering example for the same window and k-mer settings.

Low-complexity filtering remains opt-in, and the threshold remains freely configurable. Users who need the previous behavior can explicitly pass `--min-read-entropy 0.9` through the NVD CLI or `--min_read_entropy 0.9` directly to Nextflow. The independent contig-masking entropy threshold remains unchanged at 0.9.

This release also publishes a v3.3.2 parameter schema while preserving the existing v3.3.0 schema, adds behavioral coverage for both the moderate default and strict compatibility setting, and checks that native Nextflow, the Python model, and the active schema agree on the default.