### PR TITLE
v3.3.3 release candidate

### DIFF
--- a/lib/py_nvd/__init__.py
+++ b/lib/py_nvd/__init__.py
@@ -1,6 +1,6 @@
 """NVD CLI and pipeline helper library."""
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"
 
 # Re-export key modules for convenient access.
 from py_nvd import models, params, paths, presets, taxonomy

--- a/nextflow.config
+++ b/nextflow.config
@@ -347,7 +347,7 @@ manifest {
     homePage      = ''
     mainScript    = 'main.nf'
     defaultBranch = 'main'
-    version       = '3.3.2'
+    version       = '3.3.3'
     description   = ''
     author        = ''
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "William Gardner", email = "wkgardner@wisc.edu" },
 ]
 requires-python = ">= 3.11, < 3.14"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
   "altair>=6.1.0",
   "biopython>=1.85",

--- a/subworkflows/preprocess_reads.nf
+++ b/subworkflows/preprocess_reads.nf
@@ -162,20 +162,20 @@ workflow PREPROCESS_READS {
             )
         }
 
-    // 2a. Dedup
-    def should_dedup_seq = params.dedup || params.dedup_seq
-    ch_after_dedup = should_dedup_seq
-        ? DEDUP_WITH_CLUMPIFY(ch_read_batches)
-        : ch_read_batches
-
-    // 2b. Adapter trim (Illumina only)
-    ch_branched_for_trim = ch_after_dedup.branch { meta, _reads ->
+    // 2a. Adapter trim (Illumina only)
+    ch_branched_for_trim = ch_read_batches.branch { meta, _reads ->
         illumina: meta.platform == "illumina"
         other: true
     }
     ch_after_trim = params.trim_adapters
         ? TRIM_ADAPTERS(ch_branched_for_trim.illumina).mix(ch_branched_for_trim.other)
-        : ch_after_dedup
+        : ch_read_batches
+
+    // 2b. Dedup
+    def should_dedup_seq = params.dedup || params.dedup_seq
+    ch_after_dedup = should_dedup_seq
+        ? DEDUP_WITH_CLUMPIFY(ch_after_trim)
+        : ch_after_trim
 
     // 2c. Host/contaminant depletion with deacon (optional). The public
     // parameter names remain host_* for compatibility, but this channel is the
@@ -204,10 +204,10 @@ workflow PREPROCESS_READS {
         ch_depletion_index = DEACON_UNION_INDEXES.out.index
         ch_depletion_index_option = ch_depletion_index.map { idx -> tuple(true, idx) }
 
-        ch_after_scrub = DEACON_DEPLETE(ch_after_trim.combine(ch_depletion_index)).reads
+        ch_after_scrub = DEACON_DEPLETE(ch_after_dedup.combine(ch_depletion_index)).reads
     } else {
         ch_depletion_index_option = Channel.value(tuple(false, file("${projectDir}/assets/README.md")))
-        ch_after_scrub = ch_after_trim
+        ch_after_scrub = ch_after_dedup
     }
 
     // 2d. Independently optional quality/length and low-complexity filters

--- a/tests/test_read_filtering.py
+++ b/tests/test_read_filtering.py
@@ -12,6 +12,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 BBMAP_MODULE = ROOT / "modules" / "bbmap"
+PREPROCESS_READS = ROOT / "subworkflows" / "preprocess_reads"
 
 pytestmark = pytest.mark.skipif(
     shutil.which("nextflow") is None or shutil.which("bbduk.sh") is None,
@@ -248,6 +249,110 @@ def test_adapter_trimming_keeps_single_read_batches_unpaired(tmp_path: Path) -> 
 
     assert "@spot.1\n" not in output
     assert "@spot.2\n" in output
+
+
+@pytest.mark.skipif(
+    any(shutil.which(tool) is None for tool in ("clumpify.sh", "deacon")),
+    reason="preprocessing order requires locked Clumpify and Deacon",
+)
+def test_preprocessing_deduplicates_after_adapter_trimming(tmp_path: Path) -> None:
+    """Reads made identical by adapter removal collapse before preprocessing ends."""
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir()
+    shutil.copy2(ROOT / "lib" / "NvdUtils.groovy", lib_dir)
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    shutil.copy2(ROOT / "assets" / "empty_deacon.k31w1.idx", assets_dir)
+
+    reads = tmp_path / "reads.fastq.gz"
+    write_fastq(
+        reads,
+        [
+            (
+                "adapter-bearing",
+                HIGH_COMPLEXITY + ILLUMINA_ADAPTER,
+                "I" * (len(HIGH_COMPLEXITY) + len(ILLUMINA_ADAPTER)),
+            ),
+            ("already-trimmed", HIGH_COMPLEXITY, "I" * len(HIGH_COMPLEXITY)),
+        ],
+    )
+
+    workflow = tmp_path / "main.nf"
+    workflow.write_text(
+        f"""\
+nextflow.enable.dsl = 2
+
+params.no_enrichment = true
+params.virus_index = null
+params.virus_index_url = null
+params.virus_reference_fasta = null
+params.virus_abs_threshold = 1
+params.virus_rel_threshold = 0.0
+params.merge_pairs = false
+params.dedup = false
+params.dedup_seq = true
+params.trim_adapters = true
+params.host_index = null
+params.host_index_url = null
+params.host_contaminants_fasta = null
+params.filter_reads = false
+params.filter_low_complexity_reads = false
+params.min_read_quality_illumina = 20
+params.min_read_quality_nanopore = 12
+params.min_read_length = 50
+params.min_consecutive_bases = 200
+
+include {{ PREPROCESS_READS }} from '{PREPROCESS_READS}'
+
+workflow {{
+    PREPROCESS_READS(Channel.of(tuple(
+        [
+            id: 'sample_A',
+            platform: 'illumina',
+            read_mode: 'single',
+            r1_count: 1,
+            deacon_read_structure: 'single',
+        ],
+        [file('{reads}')],
+    )))
+
+    PREPROCESS_READS.out.read_batches.view {{ _id, _platform, _structure, _query_class, output ->
+        "FINAL_READS:${{output.name}}"
+    }}
+}}
+""",
+        encoding="utf-8",
+    )
+
+    environment = os.environ.copy()
+    environment["PATH"] = (
+        f"{ROOT / 'bin'}{os.pathsep}{environment['PATH']}"
+    )
+    environment["NXF_ANSI_LOG"] = "false"
+    completed = subprocess.run(  # noqa: S603
+        ["nextflow", "-C", "/dev/null", "run", str(workflow)],  # noqa: S607
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=90,
+    )
+
+    diagnostics = f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    assert completed.returncode == 0, diagnostics
+    assert "FINAL_READS:sample_A.single_read.dedup.fastq.gz" in completed.stdout
+    [output] = [
+        path
+        for path in (tmp_path / "work").glob(
+            "**/sample_A.single_read.dedup.fastq.gz",
+        )
+        if not path.is_symlink()
+    ]
+    with gzip.open(output, "rt", encoding="utf-8") as handle:
+        records = handle.read().splitlines()
+    assert len(records) == 4
+    assert records[1] == HIGH_COMPLEXITY
 
 
 def test_entropy_filter_does_not_enable_quality_filtering(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1724,7 +1724,7 @@ wheels = [
 
 [[package]]
 name = "nvd"
-version = "3.3.2"
+version = "3.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },

--- a/workflows/nvd_main.nf
+++ b/workflows/nvd_main.nf
@@ -5,7 +5,7 @@
  * preprocessing, SPAdes assembly, and two-phase BLAST verification.
  *
  * Architecture: deacon target enrichment runs first on raw R1/R2 reads
- * (outputting interleaved), then preprocessing (dedup, trim, optional host depletion, filter)
+ * (outputting interleaved), then preprocessing (trim, dedup, optional host depletion, filter)
  * operates on the enriched subset, then SPAdes and BLAST.
  */
 


### PR DESCRIPTION
This patch release changes the preprocessing order so Illumina adapter trimming runs before exact sequence deduplication.

This patch comes after observing apparent unhandled duplicates far downstream, including in the big tables. By process of elimination, we came to the conclusion that partial adapter sequences and related technical artifacts made otherwise identical reads appear unique when Clumpify ran on raw reads. Trimming first exposes only the biological portion of reads to deduplication, allowing it to more effectively collapse them before they enter downstream analysis.

Non-Illumina reads continue to bypass adapter trimming while still participating in sequence deduplication. When trimming and deduplication are both enabled, the final published preprocessed FASTQ now uses the `*.dedup.fastq.gz` suffix rather than `*.trimmed.fastq.gz`; downstream routing continues to use metadata and is unaffected.

The regression test executes the public `PREPROCESS_READS` subworkflow with real locked Deacon, BBDuk, and Clumpify tools. Two reads that become identical only after adapter removal now produce one canonical final read.